### PR TITLE
Functionality for checking if model is running.

### DIFF
--- a/ncompass/client/client.py
+++ b/ncompass/client/client.py
@@ -24,7 +24,8 @@ class nCompass():
         if self.api_key is None: api_key_not_set(custom_env_var)
 
     def start_session(self):
-        return F.start_session(self.exec_url, self.api_key) 
+        F.start_session(self.exec_url, self.api_key) 
+        self.wait_until_model_running()
     
     def stop_session(self):
         return F.stop_session(self.exec_url, self.api_key) 
@@ -64,7 +65,6 @@ class nCompassOLOC():
     def start_session(cls, api_key):
         cls.start_client(api_key)
         cls.client.start_session()
-        print(f'Waiting for model {api_key} to start...')
         cls.client.wait_until_model_running()
     
     @classmethod

--- a/ncompass/client/functional/client.py
+++ b/ncompass/client/functional/client.py
@@ -21,9 +21,17 @@ def stop_session(url, api_key):
     return start_stop_handler(get(f'{url}/stop_session', {'Authorization': api_key}))
 
 def model_is_running(url, api_key):
-    response = check_model_health(url, api_key)
-    if (response.status_code == 404) or (response.status_code == 400):
-        raise RuntimeError(response.text) 
+    try: # this try-catch looks for network connectivity issues with running check_model_health
+        response = check_model_health(url, api_key)
+    except Exception :
+        return False
+    if (response.status_code == 404):
+        # Model is not in live models dictionary
+        return False
+    elif (response.status_code == 400):
+        # Model is in live models dictionary, but not started (this is fine, just need to start
+        # session)
+        return True
     elif response.status_code == 200:
         return True
     elif response.status_code == 504:


### PR DESCRIPTION
Ensures that it handles the error msgs sent by exec server correctly so that we can have a sensible polling loop to wait for a model to start after starting it. 