### PR TITLE
Dev/removing ncompasslib refs

### DIFF
--- a/examples/basic_example/Dockerfile
+++ b/examples/basic_example/Dockerfile
@@ -31,25 +31,6 @@ RUN apt-get update -y \
 
 # Install pip s.t. it will be compatible with our PYTHON_VERSION
 RUN apt-get install -y python3-pip
-RUN python${PYTHON_VERSION} -m venv /opt/venv 
-ENV PATH="/opt/venv/bin:$PATH"
-
-# Workaround for https://github.com/openai/triton/issues/2507 and
-# https://github.com/pytorch/pytorch/issues/107960 -- hopefully
-# this won't be needed for future versions of this docker image
-# or future versions of triton.
-RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
-
-RUN --mount=type=cache,target=/root/.cache/pip \
-  pip install uv
-
-RUN ln -sf /usr/local/cuda/lib64/libcudart.so.12 /usr/local/cuda/lib64/libcudart.so
-
-RUN echo "set -o vi" >> ~/.bashrc
-RUN echo "source /opt/venv/bin/activate" >> ~/.bashrc
-
-COPY requirements.txt /tmp/requirements.txt
-RUN uv pip install -r /tmp/requirements.txt 
 
 # Create user with host UID/GID for development (avoids permission issues)
 # Handle case where UID/GID may already exist in base image (e.g., ubuntu user with UID 1000)
@@ -65,8 +46,32 @@ RUN existing_user=$(getent passwd ${HOST_UID} | cut -d: -f1 || echo ""); \
     usermod -s /bin/bash ncuser && \
     echo "ncuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Set permissions for venv
-RUN chown -R ${HOST_UID}:${HOST_GID} /opt/venv
+# Create /opt/venv directory with correct ownership BEFORE creating venv
+# This way the venv will be created with correct ownership from the start
+RUN mkdir -p /opt/venv && chown ${HOST_UID}:${HOST_GID} /opt/venv
+
+# Create venv as ncuser so it's owned by the correct user from the start
+RUN runuser -u ncuser -- python${PYTHON_VERSION} -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Workaround for https://github.com/openai/triton/issues/2507 and
+# https://github.com/pytorch/pytorch/issues/107960 -- hopefully
+# this won't be needed for future versions of this docker image
+# or future versions of triton.
+RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
+
+# Install packages as ncuser to maintain correct ownership
+RUN --mount=type=cache,target=/home/ncuser/.cache/pip \
+  runuser -u ncuser -- pip install uv
+
+RUN ln -sf /usr/local/cuda/lib64/libcudart.so.12 /usr/local/cuda/lib64/libcudart.so
+
+RUN echo "set -o vi" >> ~/.bashrc
+RUN echo "source /opt/venv/bin/activate" >> ~/.bashrc
+
+COPY requirements.txt /tmp/requirements.txt
+RUN chown ncuser:ncuser /tmp/requirements.txt && \
+    runuser -u ncuser -- uv pip install -r /tmp/requirements.txt
 
 # Copy bashrc configuration to ncuser
 RUN cp /root/.bashrc /home/ncuser/.bashrc \

--- a/examples/basic_example/requirements.txt
+++ b/examples/basic_example/requirements.txt
@@ -1,5 +1,3 @@
 requests
 pydantic>=2.0
-ncompasslib
 torch
-ncompass>=0.1.7

--- a/examples/nsys_example/Dockerfile
+++ b/examples/nsys_example/Dockerfile
@@ -32,7 +32,27 @@ RUN apt-get update -y \
 
 # Install pip
 RUN apt-get install -y python3-pip
-RUN python${PYTHON_VERSION} -m venv /opt/venv 
+
+# Create user with host UID/GID for development (avoids permission issues)
+# Handle case where UID/GID may already exist in base image (e.g., ubuntu user with UID 1000)
+RUN existing_user=$(getent passwd ${HOST_UID} | cut -d: -f1 || echo ""); \
+    if [ -n "$existing_user" ] && [ "$existing_user" != "ncuser" ]; then \
+        usermod -l ncuser -d /home/ncuser -m "$existing_user"; \
+        groupmod -n ncuser $(id -gn ncuser) 2>/dev/null || true; \
+    elif [ -z "$existing_user" ]; then \
+        groupadd -g ${HOST_GID} ncuser 2>/dev/null || true; \
+        useradd -m -u ${HOST_UID} -g ${HOST_GID} -s /bin/bash ncuser; \
+    fi && \
+    usermod -aG sudo ncuser && \
+    usermod -s /bin/bash ncuser && \
+    echo "ncuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Create /opt/venv directory with correct ownership BEFORE creating venv
+# This way the venv will be created with correct ownership from the start
+RUN mkdir -p /opt/venv && chown ${HOST_UID}:${HOST_GID} /opt/venv
+
+# Create venv as ncuser so it's owned by the correct user from the start
+RUN runuser -u ncuser -- python${PYTHON_VERSION} -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Install NVIDIA Nsight Systems CLI
@@ -51,13 +71,14 @@ RUN apt-get update -y \
 # Verify nsys installation
 RUN (nsys --version || echo "Warning: nsys not found in PATH. Ensure it's installed correctly.")
 
-# Install uv for faster pip operations
-RUN --mount=type=cache,target=/root/.cache/pip \
-  pip install uv
+# Install packages as ncuser to maintain correct ownership
+RUN --mount=type=cache,target=/home/ncuser/.cache/pip \
+  runuser -u ncuser -- pip install uv
 
-# Copy requirements and install Python dependencies
+# Copy requirements and install Python dependencies as ncuser
 COPY requirements.txt /tmp/requirements.txt
-RUN uv pip install -r /tmp/requirements.txt 
+RUN chown ncuser:ncuser /tmp/requirements.txt && \
+    runuser -u ncuser -- uv pip install -r /tmp/requirements.txt
 
 # Set up environment
 ENV PYTHONPATH=/workspace
@@ -67,23 +88,6 @@ ENV PATH="/usr/local/nsight-systems/bin:${PATH}"
 
 RUN echo "set -o vi" >> ~/.bashrc
 RUN echo "source /opt/venv/bin/activate" >> ~/.bashrc
-
-# Create user with host UID/GID for development (avoids permission issues)
-# Handle case where UID/GID may already exist in base image (e.g., ubuntu user with UID 1000)
-RUN existing_user=$(getent passwd ${HOST_UID} | cut -d: -f1 || echo ""); \
-    if [ -n "$existing_user" ] && [ "$existing_user" != "ncuser" ]; then \
-        usermod -l ncuser -d /home/ncuser -m "$existing_user"; \
-        groupmod -n ncuser $(id -gn ncuser) 2>/dev/null || true; \
-    elif [ -z "$existing_user" ]; then \
-        groupadd -g ${HOST_GID} ncuser 2>/dev/null || true; \
-        useradd -m -u ${HOST_UID} -g ${HOST_GID} -s /bin/bash ncuser; \
-    fi && \
-    usermod -aG sudo ncuser && \
-    usermod -s /bin/bash ncuser && \
-    echo "ncuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
-# Set permissions for venv
-RUN chown -R ${HOST_UID}:${HOST_GID} /opt/venv
 
 # Copy bashrc configuration to ncuser
 RUN cp /root/.bashrc /home/ncuser/.bashrc \

--- a/examples/nsys_example/requirements.txt
+++ b/examples/nsys_example/requirements.txt
@@ -1,2 +1,3 @@
-ncompass>=0.1.7
-
+requests
+pydantic>=2.0
+torch

--- a/ncompass/trace/core/config_manager.py
+++ b/ncompass/trace/core/config_manager.py
@@ -20,8 +20,8 @@ import json
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Union, Tuple
 from copy import deepcopy
-from ncompasslib.trait import Trait
-from ncompasslib.immutable import mutate
+from ncompass.types.trait import Trait
+from ncompass.types.immutable import mutate
 from enum import Enum
 from ncompass.trace.infra.utils import logger, deep_merge
 

--- a/ncompass/trace/core/loader.py
+++ b/ncompass/trace/core/loader.py
@@ -19,7 +19,7 @@ Description: Loader for AST rewriting.
 import ast
 import importlib.abc
 
-from ncompasslib.trait import Trait
+from ncompass.types.trait import Trait
 
 
 class _RewritingLoader(Trait, importlib.abc.SourceLoader):

--- a/ncompass/trace/profile/base.py
+++ b/ncompass/trace/profile/base.py
@@ -17,7 +17,7 @@ Description: Base profiling context manager.
 """
 
 from typing import Optional, Any
-from ncompasslib.trait import Trait
+from ncompass.types.trait import Trait
 
 
 class ProfileContextBase(Trait):


### PR DESCRIPTION
- Removed ncompasslib references left in ncompass
- Updated integration tests Dockerfiles to deal with venv permissions in a way that makes it faster to set user (not root) permissions, so that the docker image build time is shorter.