### PR TITLE
[BUG-FIX] Update nsys trace converter to output traceEvents: in json

### DIFF
--- a/ncompass/trace/converters/converter.py
+++ b/ncompass/trace/converters/converter.py
@@ -301,7 +301,7 @@ class NsysToChromeTraceConverter(Immutable):
         return sorted(events, key=lambda e: (e.ts, e.pid, e.tid))
     
     @mutate
-    def convert(self) -> list[ChromeTraceEvent]:
+    def convert(self) -> dict:
         """Perform the conversion.
         
         Returns:
@@ -326,7 +326,7 @@ class NsysToChromeTraceConverter(Immutable):
         # Sort events
         events = self._sort_events(events)
         
-        return events
+        return {'traceEvents': [e.to_dict() for e in events]}
 
 def convert_file(
     sqlite_path: str,
@@ -347,8 +347,7 @@ def convert_file(
                         .set_options(options)
     
     with converter_ctx as converter:
-        events = converter.convert()
+        chrome_trace = converter.convert()
         # Convert Pydantic models to dicts
-        event_dicts = [event.to_dict() for event in events]
-        write_chrome_trace(output_path, event_dicts)
+        write_chrome_trace(output_path, chrome_trace)
 

--- a/ncompass/trace/converters/parsers/cupti.py
+++ b/ncompass/trace/converters/parsers/cupti.py
@@ -51,7 +51,7 @@ class CUPTIKernelParser(BaseParser):
             event = ChromeTraceEvent(
                 name=kernel_name,
                 ph="X",
-                cat="cuda",
+                cat="kernel",
                 ts=ns_to_us(row["start"]),
                 dur=ns_to_us(row["end"] - row["start"]),
                 pid=f"Device {device_id}",

--- a/ncompass/trace/converters/utils.py
+++ b/ncompass/trace/converters/utils.py
@@ -49,7 +49,7 @@ def validate_chrome_trace(events: list[dict[str, Any]]) -> bool:
     return True
 
 
-def write_chrome_trace(output_path: str, events: list[dict[str, Any]]) -> None:
+def write_chrome_trace(output_path: str, events: dict) -> None:
     """Write Chrome Trace events to JSON file.
     
     Args:

--- a/tests/integration/test_nsys_example/golden_references/gold_nsys_example.json
+++ b/tests/integration/test_nsys_example/golden_references/gold_nsys_example.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7bd7f1a5e3061a9705e6acccd7873382a84f08a64e861d4471dd5e826b45b89
-size 3938002
+oid sha256:6dae5e6ceecb6d6b6066cb59f73268d3e510240bc82e54de4618465444bb610b
+size 3948815


### PR DESCRIPTION
- nsys converter wasn't outputing a chrometrace with 'traceEvents' as one of the keys