### PR TITLE
[FEATURE] Adding cuda profiler injector for nsys profiling

### DIFF
--- a/examples/vllm_example/client.py
+++ b/examples/vllm_example/client.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Query vLLM server with the same prompt as main.py."""
+
+import argparse
+from openai import OpenAI
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query vLLM server")
+    parser.add_argument('--host', default='localhost')
+    parser.add_argument('--port', type=int, default=8000)
+    parser.add_argument('--model', default='Qwen/Qwen2.5-0.5B')
+    args = parser.parse_args()
+
+    client = OpenAI(
+        base_url=f"http://{args.host}:{args.port}/v1",
+        api_key="dummy",  # vLLM doesn't require auth by default
+    )
+
+    # Same prompt and params as main.py
+    prompt = (
+        "Write a haiku about artificial intelligence. "
+        "End with the Haiku, don't say anything else."
+    )
+
+    completion = client.chat.completions.create(
+        model=args.model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.7,
+        top_p=0.95,
+        max_tokens=50,
+    )
+
+    print(f"Prompt: {prompt}")
+    print(f"Response: {completion.choices[0].message.content}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vllm_example/main.py
+++ b/examples/vllm_example/main.py
@@ -60,8 +60,7 @@ def run_vllm_inference(model_name: str, use_nvtx: bool = False) -> None:
         max_tokens=50
     )
 
-    with nvtx.annotate(message="ncompass_nsys_range"):
-        outputs = llm.generate([test_prompt], sampling_params)
+    outputs = llm.generate([test_prompt], sampling_params)
 
     try:
         logger.info(f"Test Prompt: {test_prompt}")

--- a/examples/vllm_example/server.py
+++ b/examples/vllm_example/server.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Launch vLLM as an OpenAI-compatible server."""
+
+import argparse
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Launch vLLM server")
+    parser.add_argument('--model', default='Qwen/Qwen2.5-0.5B',
+                        help='HuggingFace model (default: Qwen/Qwen2.5-0.5B)')
+    parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--port', type=int, default=8000)
+    args = parser.parse_args()
+
+    cmd = [
+        sys.executable, '-m', 'vllm.entrypoints.openai.api_server',
+        '--model', args.model,
+        '--host', args.host,
+        '--port', str(args.port),
+    ]
+    subprocess.run(cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/ncompass/profile/ncu.py
+++ b/ncompass/profile/ncu.py
@@ -34,7 +34,7 @@ class NcuDefaults:
 
     target_processes: str = "all"
     nvtx_include: str     = "regex:user_annotated:.*/"
-    replay_mode: str      = "application"
+    clock_control: str    = "none"
 
     def to_dict(self) -> dict[str, str]:
         """Convert to dictionary with ncu argument format (--key).
@@ -44,8 +44,8 @@ class NcuDefaults:
         """
         return {
             "--target-processes": self.target_processes,
-            "--nvtx-include": self.nvtx_include,
-            "--replay-mode": self.replay_mode,
+            "--nvtx-include":     self.nvtx_include,
+            "--clock-control":    self.clock_control,
         }
 
 

--- a/ncompass/profile/ncu.py
+++ b/ncompass/profile/ncu.py
@@ -32,9 +32,9 @@ from ncompass.profile.config import config
 class NcuDefaults:
     """Default ncu arguments for ncompass profiling."""
 
-    target_processes: str = "all"
-    nvtx_include: str     = "regex:user_annotated:.*/"
-    clock_control: str    = "none"
+    target_processes: str   = "all"
+    profile_from_start: str = "off"
+    clock_control: str      = "none"
 
     def to_dict(self) -> dict[str, str]:
         """Convert to dictionary with ncu argument format (--key).
@@ -43,9 +43,9 @@ class NcuDefaults:
         in _build_ncu_command since they don't take values.
         """
         return {
-            "--target-processes": self.target_processes,
-            "--nvtx-include":     self.nvtx_include,
-            "--clock-control":    self.clock_control,
+            "--target-processes":   self.target_processes,
+            "--profile-from-start": self.profile_from_start,
+            "--clock-control":      self.clock_control,
         }
 
 

--- a/ncompass/profile/nsys.py
+++ b/ncompass/profile/nsys.py
@@ -32,16 +32,15 @@ from ncompass.trace.infra.utils import logger
 class NsysDefaults:
     """Default nsys arguments for ncompass profiling."""
 
-    trace: str = "cuda,nvtx,osrt,cudnn,cublas,opengl,cudla"
-    sample: str = "process-tree"
-    gpuctxsw: str = "true"
-    cuda_graph_trace: str = "node"
-    stop_on_exit: str = "true"
+    trace: str                  = "cuda,nvtx,osrt,cudnn,cublas,opengl,cudla"
+    sample: str                 = "process-tree"
+    gpuctxsw: str               = "true"
+    cuda_graph_trace: str       = "node"
+    stop_on_exit: str           = "true"
     trace_fork_before_exec: str = "true"
-    force_overwrite: str = "true"
-    capture_range: str = "nvtx"
-    nvtx_capture: str = "ncompass_nsys_range"
-    capture_range_end: str = "repeat"
+    force_overwrite: str        = "true"
+    capture_range: str          = "cudaProfilerApi"
+    capture_range_end: str      = "repeat"
 
     def to_dict(self) -> dict[str, str]:
         """Convert to dictionary with nsys argument format (--key)."""
@@ -54,7 +53,6 @@ class NsysDefaults:
             "--trace-fork-before-exec": self.trace_fork_before_exec,
             "--force-overwrite": self.force_overwrite,
             "--capture-range": self.capture_range,
-            "--nvtx-capture": self.nvtx_capture,
             "--capture-range-end": self.capture_range_end,
         }
 

--- a/ncompass/trace/core/loader.py
+++ b/ncompass/trace/core/loader.py
@@ -42,13 +42,14 @@ class _RewritingLoader(Trait, importlib.abc.SourceLoader):
     def get_data(self, path: str) -> bytes:
         """Read file data as bytes."""
         return open(path, "rb").read()
-    
+
     def source_to_code(self, data, path, *, _optimize=-1):
         raise NotImplementedError
 
+
 class RewritingLoader(_RewritingLoader):
     """Loader for AST rewriting. Targets a specific file."""
-    
+
     def source_to_code(self, data, path, *, _optimize=-1):
         tree = ast.parse(data, filename=path)
         tree = self.replacer.visit(tree)

--- a/ncompass/trace/profile/cuda_profiler.py
+++ b/ncompass/trace/profile/cuda_profiler.py
@@ -1,0 +1,43 @@
+# Copyright 2025 nCompass Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Description: CUDA Profiler context manager for AST rewriting.
+"""
+
+import torch
+from typing import Optional, Any
+from ncompass.trace.profile.base import ProfileContextBase
+
+
+class CudaProfilerContext(ProfileContextBase):
+    """Context manager for torch.cuda.profiler start/stop."""
+
+    def __init__(self, name: str = "") -> None:
+        """Initialize CUDA profiler context with an optional name."""
+        self.name = name
+
+    def __enter__(self) -> "CudaProfilerContext":
+        """Start the CUDA profiler."""
+        torch.cuda.profiler.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type],
+        exc_value: Optional[Exception],
+        traceback: Optional[Any],
+    ) -> None:
+        """Stop the CUDA profiler."""
+        torch.cuda.profiler.stop()

--- a/ncompass/trace/replacers/dynamic.py
+++ b/ncompass/trace/replacers/dynamic.py
@@ -17,7 +17,7 @@ Description: Replacer classes for AST rewriting.
 """
 
 import ast
-from typing import List, Optional, cast
+from typing import List, Optional, Union, cast
 from dataclasses import dataclass, field
 
 from ncompass.trace.infra.utils import logger
@@ -55,16 +55,16 @@ class DynamicReplacerImpl:
     
     def _handle_method_transplants(self, node: ast.ClassDef) -> None:
         """Handle method transplants by replacing methods with wrappers.
-        
+
         Modifies node.body in place.
         """
         repl_map = self.class_func_replacements.get(node.name, {})  # type: ignore[attr-defined]
         if not repl_map:
             return
-        
+
         new_body: List[ast.stmt] = []
         for stmt in node.body:
-            if isinstance(stmt, ast.FunctionDef) and stmt.name in repl_map:
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)) and stmt.name in repl_map:
                 decorators = {d.id for d in stmt.decorator_list if isinstance(d, ast.Name)}
                 if "staticmethod" in decorators:
                     kind = "static"
@@ -89,7 +89,7 @@ class DynamicReplacerImpl:
         
         new_body = []
         for stmt in node.body:
-            if isinstance(stmt, ast.FunctionDef) and stmt.name in context_wrappings:
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)) and stmt.name in context_wrappings:
                 # Transform the function body to wrap specified calls with contexts
                 wrapper_config = context_wrappings[stmt.name]
                 stmt = self._wrap_function_calls_with_context(stmt, wrapper_config)
@@ -97,7 +97,7 @@ class DynamicReplacerImpl:
             new_body.append(stmt)
         node.body = new_body
 
-    def _wrap_function_calls_with_context(self, func_node: ast.FunctionDef, config: dict) -> ast.FunctionDef:
+    def _wrap_function_calls_with_context(self, func_node: Union[ast.FunctionDef, ast.AsyncFunctionDef], config: dict) -> Union[ast.FunctionDef, ast.AsyncFunctionDef]:
         """Transform function body to wrap specified calls with context managers."""
         wrap_calls = config['wrap_calls']
         
@@ -123,7 +123,7 @@ class DynamicReplacerImpl:
             level=0
         )
 
-    def _wrap_function_line_ranges_with_context(self, func_node: ast.FunctionDef, wrap_configs: List[dict]) -> ast.FunctionDef:
+    def _wrap_function_line_ranges_with_context(self, func_node: Union[ast.FunctionDef, ast.AsyncFunctionDef], wrap_configs: List[dict]) -> Union[ast.FunctionDef, ast.AsyncFunctionDef]:
         """Transform function body to wrap specified line ranges with context managers.
         
         Processes from innermost to outermost range for proper nesting support.
@@ -797,16 +797,24 @@ class DynamicReplacer(ReplacerBase, DynamicReplacerImpl):
         
         return self.generic_visit(node)
     
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
-        """Handle function line range wrapping for both methods and top-level functions."""
-        # Find all line range configs that target this function
+    def _visit_function(self, node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> ast.AST:
+        """Shared logic for function line range wrapping (sync and async)."""
         matching_configs = [
             config for config in self.func_line_range_wrappings
             if config.get('function') == node.name
         ]
-        
+
         if matching_configs:
-            logger.debug(f"[LINE_RANGE_WRAPPING] Processing function: {node.name} with {len(matching_configs)} configs")
+            func_type = "async function" if isinstance(node, ast.AsyncFunctionDef) else "function"
+            logger.debug(f"[LINE_RANGE_WRAPPING] Processing {func_type}: {node.name} with {len(matching_configs)} configs")
             node = self._wrap_function_line_ranges_with_context(node, matching_configs)
-        
+
         return self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
+        """Handle function line range wrapping for sync functions."""
+        return self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> ast.AST:
+        """Handle function line range wrapping for async functions."""
+        return self._visit_function(node)

--- a/ncompass/trace/replacers/dynamic.py
+++ b/ncompass/trace/replacers/dynamic.py
@@ -185,6 +185,38 @@ class DynamicReplacerImpl:
         func_node.body = context_imports + func_node.body
         return func_node
 
+    def _has_ancestor_in_set(self, stmt_metadata: List[dict], idx: int, ancestor_set: set) -> bool:
+        """Check if the statement at idx has any ancestor (at any nesting level) in ancestor_set.
+
+        This is used to skip nested descendants when wrapping a compound statement entirely.
+        For example, if we're wrapping a `with` statement entirely, we need to skip not just
+        its direct children, but also grandchildren (statements inside `if` blocks inside the `with`).
+
+        Args:
+            stmt_metadata: Full metadata list
+            idx: Index of the statement to check
+            ancestor_set: Set of compound statements to check against
+
+        Returns:
+            True if any ancestor of the statement is in ancestor_set
+        """
+        meta = stmt_metadata[idx]
+        parent = meta.get('parent')
+
+        while parent is not None:
+            if parent in ancestor_set:
+                return True
+            # Find the parent's metadata to get its parent
+            for other_meta in stmt_metadata:
+                if other_meta.get('stmt') is parent:
+                    parent = other_meta.get('parent')
+                    break
+            else:
+                # Parent not found in metadata, stop searching
+                break
+
+        return False
+
     def _build_statement_metadata(self, statements: List[ast.stmt], parent: Optional[ast.stmt] = None, parent_body_index: Optional[int] = None, top_level_index: Optional[int] = None) -> List[dict]:
         """Build metadata for statements, recursively flattening compound statements to atomic statements.
         
@@ -435,9 +467,11 @@ class DynamicReplacerImpl:
             
             meta = stmt_metadata[idx]
             parent = meta.get('parent')
-            
+
             # Skip if inside a compound statement we're wrapping entirely
-            if parent in processed_compound_stmts:
+            # This must check ALL ancestors, not just the immediate parent,
+            # to handle nested structures (e.g., statements inside an if that's inside a with)
+            if self._has_ancestor_in_set(stmt_metadata, idx, processed_compound_stmts):
                 continue
             
             # Add the compound statement itself if we're wrapping it entirely

--- a/ncompass_init.py
+++ b/ncompass_init.py
@@ -1,6 +1,16 @@
 import os
 import json
 from pathlib import Path
+from typing import List
+
+# Valid profiler types (actual directory names)
+VALID_PROFILER_TYPES = ("NVTX", "Torch", "CudaProfiler")
+
+# Aliases that expand to multiple profiler types
+PROFILER_ALIASES = {
+    "NSYS": ["NVTX", "CudaProfiler"]
+}
+
 
 def _log_error(cache_dir: str | None, message: str) -> None:
     """Log error to file in cache dir if available."""
@@ -12,11 +22,32 @@ def _log_error(cache_dir: str | None, message: str) -> None:
         except Exception:
             pass  # Silent fail if we can't write log
 
+
+def _parse_profiler_types(profiler_type_str: str) -> List[str]:
+    """
+    Parse profiler type string into list of profiler types.
+
+    Supports:
+    - Single type: "NVTX"
+    - Comma-separated: "NVTX,CudaProfiler"
+    - Alias: "NSYS" -> ["NVTX", "CudaProfiler"]
+    """
+    profiler_type_str = profiler_type_str.strip()
+
+    # Check if it's an alias
+    if profiler_type_str in PROFILER_ALIASES:
+        return PROFILER_ALIASES[profiler_type_str]
+
+    # Parse comma-separated list
+    types = [t.strip() for t in profiler_type_str.split(",") if t.strip()]
+    return types
+
+
 cache_dir = os.environ.get("NCOMPASS_CACHE_DIR")
-profiler_type = os.environ.get("NCOMPASS_PROFILER_TYPE")
+profiler_type_str = os.environ.get("NCOMPASS_PROFILER_TYPE")
 
 # Both must be set or both must be unset
-if bool(cache_dir) != bool(profiler_type):
+if bool(cache_dir) != bool(profiler_type_str):
     missing = "NCOMPASS_PROFILER_TYPE" if cache_dir else "NCOMPASS_CACHE_DIR"
     present = "NCOMPASS_CACHE_DIR" if cache_dir else "NCOMPASS_PROFILER_TYPE"
     msg = f"Both NCOMPASS_CACHE_DIR and NCOMPASS_PROFILER_TYPE must be set. " \
@@ -24,27 +55,63 @@ if bool(cache_dir) != bool(profiler_type):
     _log_error(cache_dir, msg)
     raise RuntimeError(msg)
 
-if cache_dir and profiler_type:
-    if profiler_type not in ("NVTX", "Torch"):
-        msg = f"NCOMPASS_PROFILER_TYPE must be 'NVTX' or 'Torch', got '{profiler_type}'"
+if cache_dir and profiler_type_str:
+    # Parse profiler types (handles aliases and comma-separated lists)
+    profiler_types = _parse_profiler_types(profiler_type_str)
+
+    if not profiler_types:
+        msg = f"NCOMPASS_PROFILER_TYPE cannot be empty"
         _log_error(cache_dir, msg)
         raise ValueError(msg)
-    
-    config_path = Path(cache_dir) / f".cache/ncompass/profiles/.default/{profiler_type}/current/config.json"
-    
-    if not config_path.exists():
-        msg = f"Config file not found: {config_path}. " \
+
+    # Validate each profiler type
+    valid_options = ", ".join(VALID_PROFILER_TYPES)
+    alias_options = ", ".join(PROFILER_ALIASES.keys())
+    for pt in profiler_types:
+        if pt not in VALID_PROFILER_TYPES:
+            msg = f"Invalid profiler type '{pt}'. " \
+                  f"Valid types: {valid_options}. " \
+                  f"Valid aliases: {alias_options}. " \
+                  f"Comma-separated lists are also supported (e.g., 'NVTX,CudaProfiler')."
+            _log_error(cache_dir, msg)
+            raise ValueError(msg)
+
+    # Load configs from each profiler type directory
+    configs = []
+    for pt in profiler_types:
+        config_path = Path(cache_dir) / f".cache/ncompass/profiles/.default/{pt}/current/config.json"
+
+        if not config_path.exists():
+            # Skip missing configs silently - allows partial configs
+            # e.g., NSYS with only NVTX markers defined
+            continue
+
+        try:
+            with open(config_path) as f:
+                cfg = json.load(f)
+                configs.append(cfg)
+        except Exception as e:
+            _log_error(cache_dir, f"Failed to load config from {config_path}: {e}")
+            raise
+
+    if not configs:
+        msg = f"No config files found for profiler types: {profiler_types}. " \
               f"Unset NCOMPASS_CACHE_DIR and NCOMPASS_PROFILER_TYPE to disable profiler."
         _log_error(cache_dir, msg)
         raise FileNotFoundError(msg)
-    
+
     try:
         from ncompass.trace.core.rewrite import enable_rewrites
         from ncompass.trace.core.pydantic import RewriteConfig
-        
-        with open(config_path) as f:
-            cfg = json.load(f)
-        enable_rewrites(config=RewriteConfig.from_dict(cfg))
+        from ncompass.trace.core.config_manager import ConfigManager
+
+        # Use ConfigManager to merge configs
+        config_manager = ConfigManager(cache_dir)
+        for cfg in configs:
+            config_manager.add_config(cfg, merge=True)
+
+        merged_cfg = config_manager.get_current_config()
+        enable_rewrites(config=RewriteConfig.from_dict(merged_cfg))
     except Exception as e:
         _log_error(cache_dir, f"Failed to enable rewrites: {e}")
         raise

--- a/tests/unit/profile/test_ncu.py
+++ b/tests/unit/profile/test_ncu.py
@@ -220,7 +220,7 @@ class TestNcuDefaults(unittest.TestCase):
         d = defaults.to_dict()
 
         self.assertEqual(d["--target-processes"], "all")
-        self.assertIn("--nvtx-include", d)
+        self.assertEqual(d["--profile-from-start"], "off")
         self.assertEqual(d["--clock-control"], "none")
 
 

--- a/tests/unit/profile/test_ncu.py
+++ b/tests/unit/profile/test_ncu.py
@@ -147,12 +147,12 @@ class TestBuildNcuCommand(unittest.TestCase):
         cmd = _build_ncu_command(
             output_path=output_path,
             metrics_str="metric1",
-            extra_args=["--target-processes", "none", "--replay-mode=kernel"],
+            extra_args=["--target-processes", "none", "--clock-control=base"],
             command=["./app"]
         )
-        
+
         self.assertIn("--target-processes=none", cmd)
-        self.assertIn("--replay-mode=kernel", cmd)
+        self.assertIn("--clock-control=base", cmd)
         self.assertNotIn("--target-processes=all", cmd)
 
 
@@ -218,10 +218,10 @@ class TestNcuDefaults(unittest.TestCase):
         """Test conversion to dictionary."""
         defaults = NcuDefaults()
         d = defaults.to_dict()
-        
+
         self.assertEqual(d["--target-processes"], "all")
         self.assertIn("--nvtx-include", d)
-        self.assertEqual(d["--replay-mode"], "application")
+        self.assertEqual(d["--clock-control"], "none")
 
 
 class TestGetMetricsStr(unittest.TestCase):

--- a/tests/unit/profile/test_nsys.py
+++ b/tests/unit/profile/test_nsys.py
@@ -29,6 +29,7 @@ from ncompass.profile.nsys import (
     check_nsys_available,
     create_trace_directory,
     run_nsys_profile,
+    NsysDefaults,
 )
 
 
@@ -219,23 +220,22 @@ class TestRunNsysProfileSuccess(unittest.TestCase):
         self.assertIn("--sample=none", cmd)
 
     @patch("subprocess.run")
-    def test_run_nsys_profile_with_range(self, mock_run):
-        """Test NVTX range capture options are included by default."""
+    def test_run_nsys_profile_with_capture_range(self, mock_run):
+        """Test cudaProfilerApi capture range is included by default."""
         mock_run.return_value = MagicMock(returncode=0)
-        
+
         expected_output = self.trace_dir / "test_output.nsys-rep"
         expected_output.touch()
-        
+
         run_nsys_profile(
             command=[str(self.script_path)],
             output_name="test_output",
             trace_dir=self.trace_dir,
             working_dir=self.script_path.parent,
         )
-        
+
         cmd = mock_run.call_args[0][0]
-        self.assertIn("--capture-range=nvtx", cmd)
-        self.assertIn("--nvtx-capture=ncompass_nsys_range", cmd)
+        self.assertIn("--capture-range=cudaProfilerApi", cmd)
         self.assertIn("--capture-range-end=repeat", cmd)
 
     @patch("subprocess.run")
@@ -508,6 +508,65 @@ class TestRunNsysProfileEdgeCases(unittest.TestCase):
         
         cmd = mock_run.call_args[0][0]
         self.assertIn("--cuda-graph-trace=graph", cmd)
+
+
+class TestNsysDefaults(unittest.TestCase):
+    """Test cases for NsysDefaults class."""
+
+    def test_to_dict_returns_nsys_argument_format(self):
+        """Test that to_dict returns dictionary with nsys argument keys."""
+        defaults = NsysDefaults()
+        d = defaults.to_dict()
+
+        # Verify keys are in nsys --key format
+        for key in d.keys():
+            self.assertTrue(key.startswith("--"), f"Key should start with '--': {key}")
+
+    def test_to_dict_contains_expected_keys(self):
+        """Test that to_dict contains all expected nsys arguments."""
+        defaults = NsysDefaults()
+        d = defaults.to_dict()
+
+        expected_keys = [
+            "--trace",
+            "--sample",
+            "--gpuctxsw",
+            "--cuda-graph-trace",
+            "--stop-on-exit",
+            "--trace-fork-before-exec",
+            "--force-overwrite",
+            "--capture-range",
+            "--capture-range-end",
+        ]
+
+        for key in expected_keys:
+            self.assertIn(key, d, f"Missing expected key: {key}")
+
+    def test_to_dict_capture_range_is_cuda_profiler_api(self):
+        """Test that capture_range defaults to cudaProfilerApi."""
+        defaults = NsysDefaults()
+        d = defaults.to_dict()
+
+        self.assertEqual(d["--capture-range"], "cudaProfilerApi")
+        self.assertEqual(d["--capture-range-end"], "repeat")
+
+    def test_to_dict_no_nvtx_capture(self):
+        """Test that to_dict does not contain nvtx-capture key."""
+        defaults = NsysDefaults()
+        d = defaults.to_dict()
+
+        # The new NsysDefaults uses cudaProfilerApi capture range instead of nvtx
+        # So nvtx-capture should not be present
+        self.assertNotIn("--nvtx-capture", d)
+
+    def test_to_dict_default_trace_types(self):
+        """Test that default trace types include cuda and nvtx."""
+        defaults = NsysDefaults()
+        d = defaults.to_dict()
+
+        trace_value = d["--trace"]
+        self.assertIn("cuda", trace_value)
+        self.assertIn("nvtx", trace_value)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_ncompass_init.py
+++ b/tests/unit/test_ncompass_init.py
@@ -1,0 +1,200 @@
+# Copyright 2025 nCompass Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for ncompass_init module.
+
+Tests the profiler type parsing and validation logic.
+"""
+
+import unittest
+
+# Import the parsing function and constants directly
+# We need to import these carefully since ncompass_init has side effects at module level
+import sys
+import importlib.util
+
+
+def _load_ncompass_init_components():
+    """Load ncompass_init module components without triggering side effects."""
+    spec = importlib.util.spec_from_file_location(
+        "ncompass_init_test",
+        "/home/ubuntu/adi/ncprof/ncompass/ncompass_init.py"
+    )
+    # We can't actually load it without side effects, so we'll test the logic directly
+    # by reimplementing the parsing function for testing
+    pass
+
+
+# Reimplement the parsing logic for testing (mirrors ncompass_init.py)
+VALID_PROFILER_TYPES = ("NVTX", "Torch", "CudaProfiler")
+PROFILER_ALIASES = {
+    "NSYS": ["NVTX", "CudaProfiler"]
+}
+
+
+def _parse_profiler_types(profiler_type_str: str) -> list[str]:
+    """
+    Parse profiler type string into list of profiler types.
+
+    Supports:
+    - Single type: "NVTX"
+    - Comma-separated: "NVTX,CudaProfiler"
+    - Alias: "NSYS" -> ["NVTX", "CudaProfiler"]
+    """
+    profiler_type_str = profiler_type_str.strip()
+
+    # Check if it's an alias
+    if profiler_type_str in PROFILER_ALIASES:
+        return PROFILER_ALIASES[profiler_type_str]
+
+    # Parse comma-separated list
+    types = [t.strip() for t in profiler_type_str.split(",") if t.strip()]
+    return types
+
+
+class TestParseProfilerTypes(unittest.TestCase):
+    """Test cases for _parse_profiler_types function."""
+
+    def test_parse_single_type_nvtx(self):
+        """Test parsing single NVTX profiler type."""
+        result = _parse_profiler_types("NVTX")
+        self.assertEqual(result, ["NVTX"])
+
+    def test_parse_single_type_torch(self):
+        """Test parsing single Torch profiler type."""
+        result = _parse_profiler_types("Torch")
+        self.assertEqual(result, ["Torch"])
+
+    def test_parse_single_type_cuda_profiler(self):
+        """Test parsing single CudaProfiler type."""
+        result = _parse_profiler_types("CudaProfiler")
+        self.assertEqual(result, ["CudaProfiler"])
+
+    def test_parse_comma_separated_two_types(self):
+        """Test parsing comma-separated list of two types."""
+        result = _parse_profiler_types("NVTX,CudaProfiler")
+        self.assertEqual(result, ["NVTX", "CudaProfiler"])
+
+    def test_parse_comma_separated_all_types(self):
+        """Test parsing comma-separated list of all valid types."""
+        result = _parse_profiler_types("NVTX,Torch,CudaProfiler")
+        self.assertEqual(result, ["NVTX", "Torch", "CudaProfiler"])
+
+    def test_parse_comma_separated_with_spaces(self):
+        """Test parsing comma-separated list with spaces."""
+        result = _parse_profiler_types("NVTX, CudaProfiler")
+        self.assertEqual(result, ["NVTX", "CudaProfiler"])
+
+    def test_parse_comma_separated_with_extra_spaces(self):
+        """Test parsing handles extra whitespace."""
+        result = _parse_profiler_types("  NVTX ,  Torch  ")
+        self.assertEqual(result, ["NVTX", "Torch"])
+
+    def test_parse_nsys_alias(self):
+        """Test NSYS alias expands to NVTX and CudaProfiler."""
+        result = _parse_profiler_types("NSYS")
+        self.assertEqual(result, ["NVTX", "CudaProfiler"])
+
+    def test_parse_empty_string(self):
+        """Test parsing empty string returns empty list."""
+        result = _parse_profiler_types("")
+        self.assertEqual(result, [])
+
+    def test_parse_whitespace_only(self):
+        """Test parsing whitespace-only string returns empty list."""
+        result = _parse_profiler_types("   ")
+        self.assertEqual(result, [])
+
+    def test_parse_trailing_comma(self):
+        """Test parsing handles trailing comma."""
+        result = _parse_profiler_types("NVTX,")
+        self.assertEqual(result, ["NVTX"])
+
+    def test_parse_leading_comma(self):
+        """Test parsing handles leading comma."""
+        result = _parse_profiler_types(",NVTX")
+        self.assertEqual(result, ["NVTX"])
+
+
+class TestValidProfilerTypes(unittest.TestCase):
+    """Test cases for profiler type validation."""
+
+    def test_valid_profiler_types_contains_nvtx(self):
+        """Test NVTX is a valid profiler type."""
+        self.assertIn("NVTX", VALID_PROFILER_TYPES)
+
+    def test_valid_profiler_types_contains_torch(self):
+        """Test Torch is a valid profiler type."""
+        self.assertIn("Torch", VALID_PROFILER_TYPES)
+
+    def test_valid_profiler_types_contains_cuda_profiler(self):
+        """Test CudaProfiler is a valid profiler type."""
+        self.assertIn("CudaProfiler", VALID_PROFILER_TYPES)
+
+    def test_valid_profiler_types_count(self):
+        """Test there are exactly 3 valid profiler types."""
+        self.assertEqual(len(VALID_PROFILER_TYPES), 3)
+
+
+class TestProfilerAliases(unittest.TestCase):
+    """Test cases for profiler aliases."""
+
+    def test_nsys_alias_exists(self):
+        """Test NSYS alias is defined."""
+        self.assertIn("NSYS", PROFILER_ALIASES)
+
+    def test_nsys_alias_expands_to_nvtx(self):
+        """Test NSYS alias includes NVTX."""
+        self.assertIn("NVTX", PROFILER_ALIASES["NSYS"])
+
+    def test_nsys_alias_expands_to_cuda_profiler(self):
+        """Test NSYS alias includes CudaProfiler."""
+        self.assertIn("CudaProfiler", PROFILER_ALIASES["NSYS"])
+
+    def test_nsys_alias_count(self):
+        """Test NSYS alias expands to exactly 2 types."""
+        self.assertEqual(len(PROFILER_ALIASES["NSYS"]), 2)
+
+
+class TestProfilerTypeValidation(unittest.TestCase):
+    """Test cases for validating profiler types against VALID_PROFILER_TYPES."""
+
+    def test_valid_type_passes(self):
+        """Test valid profiler type passes validation."""
+        parsed = _parse_profiler_types("NVTX")
+        for pt in parsed:
+            self.assertIn(pt, VALID_PROFILER_TYPES)
+
+    def test_invalid_type_not_in_valid_list(self):
+        """Test invalid profiler type is not in valid list."""
+        parsed = _parse_profiler_types("InvalidType")
+        for pt in parsed:
+            self.assertNotIn(pt, VALID_PROFILER_TYPES)
+
+    def test_nsys_alias_types_are_valid(self):
+        """Test all types in NSYS alias are valid."""
+        nsys_types = PROFILER_ALIASES["NSYS"]
+        for pt in nsys_types:
+            self.assertIn(pt, VALID_PROFILER_TYPES)
+
+    def test_case_sensitive_validation(self):
+        """Test profiler type validation is case-sensitive."""
+        # 'nvtx' (lowercase) should not be in valid types
+        self.assertNotIn("nvtx", VALID_PROFILER_TYPES)
+        self.assertNotIn("torch", VALID_PROFILER_TYPES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/trace/test_cuda_profiler.py
+++ b/tests/unit/trace/test_cuda_profiler.py
@@ -1,0 +1,151 @@
+# Copyright 2025 nCompass Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for ncompass.trace.profile.cuda_profiler module.
+
+Tests the CudaProfilerContext context manager for CUDA profiler start/stop.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+
+# Mock torch before importing cuda_profiler module
+mock_torch = MagicMock()
+sys.modules['torch'] = mock_torch
+
+
+class TestCudaProfilerContext(unittest.TestCase):
+    """Test cases for CudaProfilerContext class."""
+
+    def setUp(self):
+        """Reset mock before each test."""
+        mock_torch.reset_mock()
+
+    def test_init_default_name(self):
+        """Test CudaProfilerContext initializes with empty name by default."""
+        from ncompass.trace.profile.cuda_profiler import CudaProfilerContext
+
+        ctx = CudaProfilerContext()
+        self.assertEqual(ctx.name, "")
+
+    def test_init_with_name(self):
+        """Test CudaProfilerContext initializes with provided name."""
+        from ncompass.trace.profile.cuda_profiler import CudaProfilerContext
+
+        ctx = CudaProfilerContext(name="test_region")
+        self.assertEqual(ctx.name, "test_region")
+
+    def test_enter_starts_profiler(self):
+        """Test __enter__ calls torch.cuda.profiler.start()."""
+        from ncompass.trace.profile.cuda_profiler import CudaProfilerContext
+
+        ctx = CudaProfilerContext()
+        result = ctx.__enter__()
+
+        mock_torch.cuda.profiler.start.assert_called_once()
+        self.assertIs(result, ctx)
+
+    def test_exit_stops_profiler(self):
+        """Test __exit__ calls torch.cuda.profiler.stop()."""
+        from ncompass.trace.profile.cuda_profiler import CudaProfilerContext
+
+        ctx = CudaProfilerContext()
+        ctx.__exit__(None, None, None)
+
+        mock_torch.cuda.profiler.stop.assert_called_once()
+
+    def test_context_manager_usage(self):
+        """Test CudaProfilerContext works as a context manager."""
+        from ncompass.trace.profile.cuda_profiler import CudaProfilerContext
+
+        with CudaProfilerContext(name="test"):
+            # Verify start was called when entering
+            mock_torch.cuda.profiler.start.assert_called_once()
+            mock_torch.cuda.profiler.stop.assert_not_called()
+
+        # Verify stop was called when exiting
+        mock_torch.cuda.profiler.stop.assert_called_once()
+
+    def test_exit_with_exception(self):
+        """Test __exit__ is called even when exception occurs."""
+        from ncompass.trace.profile.cuda_profiler import CudaProfilerContext
+
+        try:
+            with CudaProfilerContext():
+                raise ValueError("test error")
+        except ValueError:
+            pass
+
+        # Verify stop was still called despite exception
+        mock_torch.cuda.profiler.stop.assert_called_once()
+
+    def test_exit_returns_none(self):
+        """Test __exit__ returns None (doesn't suppress exceptions)."""
+        from ncompass.trace.profile.cuda_profiler import CudaProfilerContext
+
+        ctx = CudaProfilerContext()
+        result = ctx.__exit__(ValueError, ValueError("test"), None)
+
+        # None means exception is not suppressed
+        self.assertIsNone(result)
+
+    def test_inherits_from_profile_context_base(self):
+        """Test CudaProfilerContext inherits from ProfileContextBase."""
+        from ncompass.trace.profile.cuda_profiler import CudaProfilerContext
+        from ncompass.trace.profile.base import ProfileContextBase
+
+        ctx = CudaProfilerContext()
+        self.assertIsInstance(ctx, ProfileContextBase)
+
+
+class TestCudaProfilerContextIntegration(unittest.TestCase):
+    """Integration-style tests for CudaProfilerContext."""
+
+    def setUp(self):
+        """Reset mock before each test."""
+        mock_torch.reset_mock()
+
+    def test_multiple_context_managers(self):
+        """Test multiple CudaProfilerContext instances work independently."""
+        from ncompass.trace.profile.cuda_profiler import CudaProfilerContext
+
+        with CudaProfilerContext(name="outer"):
+            self.assertEqual(mock_torch.cuda.profiler.start.call_count, 1)
+
+            with CudaProfilerContext(name="inner"):
+                self.assertEqual(mock_torch.cuda.profiler.start.call_count, 2)
+
+            self.assertEqual(mock_torch.cuda.profiler.stop.call_count, 1)
+
+        self.assertEqual(mock_torch.cuda.profiler.stop.call_count, 2)
+
+    def test_sequential_context_managers(self):
+        """Test sequential CudaProfilerContext usage."""
+        from ncompass.trace.profile.cuda_profiler import CudaProfilerContext
+
+        with CudaProfilerContext(name="first"):
+            pass
+
+        with CudaProfilerContext(name="second"):
+            pass
+
+        self.assertEqual(mock_torch.cuda.profiler.start.call_count, 2)
+        self.assertEqual(mock_torch.cuda.profiler.stop.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/trace/test_replacer.py
+++ b/tests/unit/trace/test_replacer.py
@@ -2251,5 +2251,474 @@ class TestStatementFlattening(unittest.TestCase):
         top_level_withs = [stmt for stmt in non_import_stmts if isinstance(stmt, ast.With)]
         self.assertEqual(len(top_level_withs), 0, "For loop should not be wrapped at top level")
 
+
+class TestAsyncMethodTransplants(unittest.TestCase):
+    """Test cases for async method transplant (replacement) functionality."""
+
+    def setUp(self):
+        """Set up test fixtures with a custom replacer for async method replacement."""
+        self.replacer = DynamicReplacer(
+            _fullname="test.async.transplant",
+            _class_replacements={},
+            _class_func_replacements={
+                "AsyncTestClass": {
+                    "async_old_method": "replacement.module.ReplacementClass.new_async_method",
+                }
+            }
+        )
+
+    def test_async_method_replacement_creates_wrapper(self):
+        """Test that async method replacement creates proper wrapper with import."""
+        # Create a class with an async method to be replaced
+        async_old_method = ast.AsyncFunctionDef(
+            name="async_old_method",
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="self", annotation=None)],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[ast.Pass()],
+            decorator_list=[],
+            returns=None
+        )
+
+        unchanged_method = ast.FunctionDef(
+            name="unchanged_method",
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="self", annotation=None)],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[ast.Pass()],
+            decorator_list=[],
+            returns=None
+        )
+
+        class_node = ast.ClassDef(
+            name="AsyncTestClass",
+            bases=[],
+            keywords=[],
+            decorator_list=[],
+            body=[async_old_method, unchanged_method]
+        )
+
+        result = self.replacer.visit_ClassDef(class_node)
+
+        # Should return the modified class
+        self.assertIsInstance(result, ast.ClassDef)
+        self.assertEqual(result.name, "AsyncTestClass")
+        self.assertEqual(len(result.body), 2)  # wrapper + unchanged_method
+
+        # First should be the wrapper function (should be FunctionDef, not async)
+        wrapper_func = result.body[0]
+        self.assertIsInstance(wrapper_func, ast.FunctionDef)
+        self.assertEqual(wrapper_func.name, "async_old_method")
+
+        # Check wrapper function structure
+        self.assertEqual(len(wrapper_func.body), 2)  # import + return
+
+        # First statement should be import
+        import_stmt = wrapper_func.body[0]
+        self.assertIsInstance(import_stmt, ast.ImportFrom)
+        self.assertEqual(import_stmt.module, "replacement.module")
+        self.assertEqual(import_stmt.names[0].name, "ReplacementClass")
+
+        # Second statement should be return with method call
+        return_stmt = wrapper_func.body[1]
+        self.assertIsInstance(return_stmt, ast.Return)
+        call = return_stmt.value
+        self.assertIsInstance(call.func, ast.Attribute)
+        self.assertEqual(call.func.attr, "new_async_method")
+
+    def test_async_method_not_in_config_unchanged(self):
+        """Test that async methods not in replacement config are unchanged."""
+        # Create a class with an async method that's NOT in the replacement config
+        other_async_method = ast.AsyncFunctionDef(
+            name="other_async_method",  # Not in config
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="self", annotation=None)],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[ast.Pass()],
+            decorator_list=[],
+            returns=None
+        )
+
+        class_node = ast.ClassDef(
+            name="AsyncTestClass",
+            bases=[],
+            keywords=[],
+            decorator_list=[],
+            body=[other_async_method]
+        )
+
+        result = self.replacer.visit_ClassDef(class_node)
+
+        # Should return the class with unchanged async method
+        self.assertIsInstance(result, ast.ClassDef)
+        self.assertEqual(len(result.body), 1)
+
+        # Should still be an AsyncFunctionDef (not replaced)
+        self.assertIsInstance(result.body[0], ast.AsyncFunctionDef)
+        self.assertEqual(result.body[0].name, "other_async_method")
+
+    def test_mixed_sync_and_async_method_replacement(self):
+        """Test that both sync and async methods can be replaced in same class."""
+        replacer = DynamicReplacer(
+            _fullname="test.mixed.transplant",
+            _class_replacements={},
+            _class_func_replacements={
+                "MixedClass": {
+                    "sync_method": "sync.module.SyncReplacement.sync_replacement",
+                    "async_method": "async.module.AsyncReplacement.async_replacement",
+                }
+            }
+        )
+
+        sync_method = ast.FunctionDef(
+            name="sync_method",
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="self", annotation=None)],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[ast.Pass()],
+            decorator_list=[],
+            returns=None
+        )
+
+        async_method = ast.AsyncFunctionDef(
+            name="async_method",
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="self", annotation=None)],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[ast.Pass()],
+            decorator_list=[],
+            returns=None
+        )
+
+        class_node = ast.ClassDef(
+            name="MixedClass",
+            bases=[],
+            keywords=[],
+            decorator_list=[],
+            body=[sync_method, async_method]
+        )
+
+        result = replacer.visit_ClassDef(class_node)
+
+        # Should return the class with both methods replaced
+        self.assertIsInstance(result, ast.ClassDef)
+        self.assertEqual(len(result.body), 2)
+
+        # Both should be wrappers (FunctionDef)
+        wrapper1 = result.body[0]
+        wrapper2 = result.body[1]
+
+        self.assertIsInstance(wrapper1, ast.FunctionDef)
+        self.assertIsInstance(wrapper2, ast.FunctionDef)
+
+        # Check wrapper names
+        wrapper_names = {wrapper1.name, wrapper2.name}
+        self.assertEqual(wrapper_names, {"sync_method", "async_method"})
+
+        # Verify imports for each wrapper
+        for wrapper in [wrapper1, wrapper2]:
+            self.assertIsInstance(wrapper.body[0], ast.ImportFrom)
+            self.assertIsInstance(wrapper.body[1], ast.Return)
+
+
+class TestAsyncFunctionLineRangeWrapping(unittest.TestCase):
+    """Test cases for async function line range wrapping functionality."""
+
+    def setUp(self):
+        """Set up test fixtures with a custom replacer."""
+        self.replacer = DynamicReplacer(
+            _fullname="test.async.range",
+            _class_replacements={},
+            _class_func_replacements={},
+            _func_line_range_wrappings=[
+                {
+                    'function': 'async_test_method',
+                    'start_line': 10,
+                    'end_line': 12,
+                    'context_class': 'test.context.TestContext',
+                    'context_values': []
+                }
+            ]
+        )
+
+    def test_async_function_line_range_wrapping(self):
+        """Test that async functions can have line ranges wrapped."""
+        # Create an async function with statements that will be wrapped
+        async_method = ast.AsyncFunctionDef(
+            name="async_test_method",
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="self", annotation=None)],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[
+                ast.Assign(
+                    targets=[ast.Name(id="x", ctx=ast.Store())],
+                    value=ast.Constant(value=1),
+                    lineno=10
+                ),
+                ast.Assign(
+                    targets=[ast.Name(id="y", ctx=ast.Store())],
+                    value=ast.Constant(value=2),
+                    lineno=11
+                ),
+                ast.Assign(
+                    targets=[ast.Name(id="z", ctx=ast.Store())],
+                    value=ast.Constant(value=3),
+                    lineno=12
+                ),
+            ],
+            decorator_list=[],
+            returns=None,
+            lineno=9
+        )
+
+        # Visit the async function directly
+        result = self.replacer.visit_AsyncFunctionDef(async_method)
+
+        # Should still be an AsyncFunctionDef
+        self.assertIsInstance(result, ast.AsyncFunctionDef)
+
+        # Should have an import and a With statement wrapping the assignments
+        self.assertTrue(len(result.body) >= 2)
+
+        # First statement should be an import
+        self.assertIsInstance(result.body[0], ast.ImportFrom)
+        self.assertEqual(result.body[0].module, "test.context")
+        self.assertEqual(result.body[0].names[0].name, "TestContext")
+
+        # Second statement should be a With wrapping the assignments
+        self.assertIsInstance(result.body[1], ast.With)
+        with_stmt = result.body[1]
+        self.assertEqual(len(with_stmt.body), 3)  # 3 wrapped assignments
+
+    def test_async_function_preserves_await_expressions(self):
+        """Test that await expressions inside async functions are preserved."""
+        replacer = DynamicReplacer(
+            _fullname="test.async.await",
+            _class_replacements={},
+            _class_func_replacements={},
+            _func_line_range_wrappings=[
+                {
+                    'function': 'async_with_await',
+                    'start_line': 10,
+                    'end_line': 11,
+                    'context_class': 'test.context.TestContext',
+                    'context_values': []
+                }
+            ]
+        )
+
+        # Create an async function with await expression
+        async_method = ast.AsyncFunctionDef(
+            name="async_with_await",
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="self", annotation=None)],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[
+                ast.Expr(
+                    value=ast.Await(
+                        value=ast.Call(
+                            func=ast.Name(id="some_async_func", ctx=ast.Load()),
+                            args=[],
+                            keywords=[]
+                        )
+                    ),
+                    lineno=10
+                ),
+                ast.Assign(
+                    targets=[ast.Name(id="result", ctx=ast.Store())],
+                    value=ast.Constant(value=42),
+                    lineno=11
+                ),
+            ],
+            decorator_list=[],
+            returns=None,
+            lineno=9
+        )
+
+        result = replacer.visit_AsyncFunctionDef(async_method)
+
+        # Should still be an AsyncFunctionDef
+        self.assertIsInstance(result, ast.AsyncFunctionDef)
+
+        # Find the With statement
+        with_stmts = [stmt for stmt in result.body if isinstance(stmt, ast.With)]
+        self.assertEqual(len(with_stmts), 1)
+
+        # The await should be preserved inside the With body
+        with_body = with_stmts[0].body
+        await_exprs = [
+            stmt for stmt in with_body
+            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Await)
+        ]
+        self.assertEqual(len(await_exprs), 1)
+
+    def test_async_function_not_targeted_unchanged(self):
+        """Test that async functions not in config are unchanged."""
+        # Create an async function that's NOT in the wrapping config
+        other_async_method = ast.AsyncFunctionDef(
+            name="other_async_method",  # Not 'async_test_method'
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="self", annotation=None)],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[
+                ast.Assign(
+                    targets=[ast.Name(id="x", ctx=ast.Store())],
+                    value=ast.Constant(value=1),
+                    lineno=10
+                ),
+            ],
+            decorator_list=[],
+            returns=None,
+            lineno=9
+        )
+
+        result = self.replacer.visit_AsyncFunctionDef(other_async_method)
+
+        # Should still be an AsyncFunctionDef
+        self.assertIsInstance(result, ast.AsyncFunctionDef)
+
+        # Body should be unchanged (no import, no With wrapper)
+        self.assertEqual(len(result.body), 1)
+        self.assertIsInstance(result.body[0], ast.Assign)
+
+    def test_sync_and_async_functions_both_wrapped(self):
+        """Test that both sync and async functions can be wrapped by same replacer."""
+        replacer = DynamicReplacer(
+            _fullname="test.mixed",
+            _class_replacements={},
+            _class_func_replacements={},
+            _func_line_range_wrappings=[
+                {
+                    'function': 'sync_method',
+                    'start_line': 10,
+                    'end_line': 10,
+                    'context_class': 'test.sync.SyncContext',
+                    'context_values': []
+                },
+                {
+                    'function': 'async_method',
+                    'start_line': 10,
+                    'end_line': 10,
+                    'context_class': 'test.async_mod.AsyncContext',
+                    'context_values': []
+                }
+            ]
+        )
+
+        # Create sync function
+        sync_method = ast.FunctionDef(
+            name="sync_method",
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[
+                ast.Assign(
+                    targets=[ast.Name(id="x", ctx=ast.Store())],
+                    value=ast.Constant(value=1),
+                    lineno=10
+                ),
+            ],
+            decorator_list=[],
+            returns=None,
+            lineno=9
+        )
+
+        # Create async function
+        async_method = ast.AsyncFunctionDef(
+            name="async_method",
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[
+                ast.Assign(
+                    targets=[ast.Name(id="y", ctx=ast.Store())],
+                    value=ast.Constant(value=2),
+                    lineno=10
+                ),
+            ],
+            decorator_list=[],
+            returns=None,
+            lineno=9
+        )
+
+        # Visit both
+        sync_result = replacer.visit_FunctionDef(sync_method)
+        async_result = replacer.visit_AsyncFunctionDef(async_method)
+
+        # Sync should be wrapped with SyncContext
+        self.assertIsInstance(sync_result, ast.FunctionDef)
+        sync_imports = [s for s in sync_result.body if isinstance(s, ast.ImportFrom)]
+        self.assertEqual(len(sync_imports), 1)
+        self.assertEqual(sync_imports[0].module, "test.sync")
+        self.assertEqual(sync_imports[0].names[0].name, "SyncContext")
+
+        # Async should be wrapped with AsyncContext
+        self.assertIsInstance(async_result, ast.AsyncFunctionDef)
+        async_imports = [s for s in async_result.body if isinstance(s, ast.ImportFrom)]
+        self.assertEqual(len(async_imports), 1)
+        self.assertEqual(async_imports[0].module, "test.async_mod")
+        self.assertEqual(async_imports[0].names[0].name, "AsyncContext")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/trace/test_replacer.py
+++ b/tests/unit/trace/test_replacer.py
@@ -2251,6 +2251,253 @@ class TestStatementFlattening(unittest.TestCase):
         top_level_withs = [stmt for stmt in non_import_stmts if isinstance(stmt, ast.With)]
         self.assertEqual(len(top_level_withs), 0, "For loop should not be wrapped at top level")
 
+    def test_wrap_all_children_of_with_via_overlap_no_duplicate_nested_statements(self):
+        """Test that wrapping all children of a with statement via overlap doesn't duplicate nested statements.
+
+        This tests the bug fix for the scenario where:
+        - with statement at line 10 (not in wrap range directly)
+        - if statement at line 11 (first child of with, in wrap range)
+        - statements inside if.body and if.orelse (nested in wrap range)
+        - wrap range is 11-22 (covers all children but not the with header)
+
+        The bug was: nested statements inside if.body and if.orelse were being duplicated
+        in the wrapper's body, causing them to execute unconditionally regardless of the
+        if condition. This caused "too many values to unpack" errors in vLLM when wrapping
+        postprocess sections.
+
+        Expected behavior:
+        - The with statement should be wrapped entirely (because all its children are in range)
+        - Nested statements should NOT be duplicated outside the if/else structure
+        """
+        replacer = DynamicReplacer(
+            _fullname="test.overlap_nested",
+            _class_replacements={},
+            _class_func_replacements={},
+            _func_line_range_wrappings=[
+                {
+                    'function': 'test_method',
+                    'start_line': 11,  # First child of with
+                    'end_line': 22,    # Lines outside the with
+                    'context_class': 'profiler.CudaProfilerContext',
+                    'context_values': [{'name': 'name', 'value': 'test_region', 'type': 'literal'}]
+                }
+            ]
+        )
+
+        # Create a function with a with statement containing an if/else
+        # This mimics the vLLM gpu_model_runner structure
+        test_method = ast.FunctionDef(
+            name="test_method",
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="self", annotation=None)],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            ),
+            body=[
+                # Line 5: model_output = self._model_forward()
+                ast.Assign(
+                    targets=[ast.Name(id="model_output", ctx=ast.Store())],
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="self", ctx=ast.Load()),
+                            attr="_model_forward",
+                            ctx=ast.Load()
+                        ),
+                        args=[],
+                        keywords=[]
+                    ),
+                    lineno=5
+                ),
+                # Line 10: with record_function_or_nullcontext("postprocess"):
+                (with_stmt := ast.With(
+                    items=[
+                        ast.withitem(
+                            context_expr=ast.Call(
+                                func=ast.Name(id="record_function_or_nullcontext", ctx=ast.Load()),
+                                args=[ast.Constant(value="postprocess")],
+                                keywords=[]
+                            )
+                        )
+                    ],
+                    body=[
+                        # Line 11: if self.use_aux_hidden_state_outputs:
+                        (if_stmt := ast.If(
+                            test=ast.Attribute(
+                                value=ast.Name(id="self", ctx=ast.Load()),
+                                attr="use_aux_hidden_state_outputs",
+                                ctx=ast.Load()
+                            ),
+                            body=[
+                                # Line 12: hidden_states, aux_hidden_states = model_output
+                                ast.Assign(
+                                    targets=[
+                                        ast.Tuple(
+                                            elts=[
+                                                ast.Name(id="hidden_states", ctx=ast.Store()),
+                                                ast.Name(id="aux_hidden_states", ctx=ast.Store())
+                                            ],
+                                            ctx=ast.Store()
+                                        )
+                                    ],
+                                    value=ast.Name(id="model_output", ctx=ast.Load()),
+                                    lineno=12
+                                )
+                            ],
+                            orelse=[
+                                # Line 14: hidden_states = model_output
+                                ast.Assign(
+                                    targets=[ast.Name(id="hidden_states", ctx=ast.Store())],
+                                    value=ast.Name(id="model_output", ctx=ast.Load()),
+                                    lineno=14
+                                ),
+                                # Line 15: aux_hidden_states = None
+                                ast.Assign(
+                                    targets=[ast.Name(id="aux_hidden_states", ctx=ast.Store())],
+                                    value=ast.Constant(value=None),
+                                    lineno=15
+                                )
+                            ],
+                            lineno=11
+                        )),
+                        # Line 17: if not self.broadcast_pp_output:
+                        ast.If(
+                            test=ast.UnaryOp(
+                                op=ast.Not(),
+                                operand=ast.Attribute(
+                                    value=ast.Name(id="self", ctx=ast.Load()),
+                                    attr="broadcast_pp_output",
+                                    ctx=ast.Load()
+                                )
+                            ),
+                            body=[
+                                # Line 18: return hidden_states
+                                ast.Return(
+                                    value=ast.Name(id="hidden_states", ctx=ast.Load()),
+                                    lineno=18
+                                )
+                            ],
+                            orelse=[],
+                            lineno=17
+                        )
+                    ],
+                    lineno=10
+                )),
+                # Line 21: self.execute_model_state = hidden_states (outside the with)
+                ast.Assign(
+                    targets=[
+                        ast.Attribute(
+                            value=ast.Name(id="self", ctx=ast.Load()),
+                            attr="execute_model_state",
+                            ctx=ast.Store()
+                        )
+                    ],
+                    value=ast.Name(id="hidden_states", ctx=ast.Load()),
+                    lineno=21
+                ),
+                # Line 22: self.result = aux_hidden_states (outside the with)
+                ast.Assign(
+                    targets=[
+                        ast.Attribute(
+                            value=ast.Name(id="self", ctx=ast.Load()),
+                            attr="result",
+                            ctx=ast.Store()
+                        )
+                    ],
+                    value=ast.Name(id="aux_hidden_states", ctx=ast.Load()),
+                    lineno=22
+                ),
+                # Line 23: return None
+                ast.Return(
+                    value=ast.Constant(value=None),
+                    lineno=23
+                )
+            ],
+            decorator_list=[],
+            returns=None,
+            lineno=1
+        )
+
+        # Set end_lineno for compound statements
+        with_stmt.end_lineno = 19
+        if_stmt.end_lineno = 15
+
+        class_node = ast.ClassDef(
+            name="TestClass",
+            bases=[],
+            keywords=[],
+            decorator_list=[],
+            body=[test_method]
+        )
+
+        result = replacer.visit_ClassDef(class_node)
+        modified_method = result.body[0]
+
+        # Get non-import statements
+        non_import_stmts = [stmt for stmt in modified_method.body if not isinstance(stmt, ast.ImportFrom)]
+
+        # Find the outer wrapper (CudaProfilerContext)
+        outer_wrapper = None
+        for stmt in non_import_stmts:
+            if isinstance(stmt, ast.With):
+                # Check if it's the CudaProfilerContext wrapper
+                context_expr = stmt.items[0].context_expr
+                if isinstance(context_expr, ast.Call) and isinstance(context_expr.func, ast.Name):
+                    if context_expr.func.id == "CudaProfilerContext":
+                        outer_wrapper = stmt
+                        break
+
+        self.assertIsNotNone(outer_wrapper, "Should have CudaProfilerContext wrapper")
+
+        # The wrapper's body should contain:
+        # 1. The original with statement (record_function_or_nullcontext)
+        # 2. The two assign statements from outside the original with (self.execute_model_state and self.result)
+        # It should NOT contain duplicated assignments from inside the if/else
+
+        # Count how many Assign statements are directly in the wrapper body
+        # (not inside the nested with or if statements)
+        direct_assigns_in_wrapper = [
+            stmt for stmt in outer_wrapper.body
+            if isinstance(stmt, ast.Assign)
+        ]
+
+        # Should be exactly 2 assigns (the ones outside the original with)
+        self.assertEqual(
+            len(direct_assigns_in_wrapper), 2,
+            f"Wrapper body should have exactly 2 direct Assign statements (from outside original with), "
+            f"but found {len(direct_assigns_in_wrapper)}. "
+            f"This indicates nested statements are being incorrectly duplicated."
+        )
+
+        # Verify the nested with statement is preserved and contains the if/else
+        nested_withs = [stmt for stmt in outer_wrapper.body if isinstance(stmt, ast.With)]
+        self.assertEqual(len(nested_withs), 1, "Should have one nested with statement")
+
+        inner_with = nested_withs[0]
+        # Check that the inner with's body contains the if statement
+        inner_if_stmts = [stmt for stmt in inner_with.body if isinstance(stmt, ast.If)]
+        self.assertEqual(len(inner_if_stmts), 2, "Inner with should have two if statements")
+
+        # Verify the if/else structure is intact
+        first_if = inner_if_stmts[0]
+        self.assertEqual(len(first_if.body), 1, "First if body should have 1 statement (tuple unpacking)")
+        self.assertEqual(len(first_if.orelse), 2, "First if orelse should have 2 statements")
+
+        # Verify the tuple unpacking is only in the if body, not duplicated
+        tuple_unpacking_count = 0
+        for stmt in outer_wrapper.body:
+            if isinstance(stmt, ast.Assign):
+                if isinstance(stmt.targets[0], ast.Tuple):
+                    tuple_unpacking_count += 1
+
+        self.assertEqual(
+            tuple_unpacking_count, 0,
+            "Tuple unpacking should NOT appear directly in wrapper body - it should only be in the if branch"
+        )
+
 
 class TestAsyncMethodTransplants(unittest.TestCase):
     """Test cases for async method transplant (replacement) functionality."""


### PR DESCRIPTION
- Updated ncompass_init to have NSYS alias and NVTX, CudaProfiler and Torch types
- Added context for injecting torch.cuda.profiler.start/stop() calls
- Added tests for new nsys and cuda profiler changes
- Integrated updated ncompass examples directory structure